### PR TITLE
meson: using built-in warning_level instead of using "-Wall"

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,5 @@
-project('wlpinyin',['c'])
-
-add_global_arguments(['-Wall'], language : 'c')
+project('wlpinyin',['c'],
+  default_options : ['warning_level=1'])
 
 wl_client = dependency('wayland-client')
 wl_protocols = dependency('wayland-protocols')


### PR DESCRIPTION
When using "-Wall", meson will complain:
	meson.build:3: WARNING: Consider using the built-in warning_level option instead of using "-Wall".
"warning_level=1" is same as "-Wall".