### PR TITLE
fix im toggle by accident

### DIFF
--- a/config.c
+++ b/config.c
@@ -4,5 +4,5 @@ static xkb_keysym_t records[2];
 bool im_toggle(struct xkb_state *xkb, xkb_keysym_t keysym, bool pressed) {
 	records[1] = records[0];
 	records[0] = keysym;
-	return records[0] == XKB_KEY_Control_L && records[1] == XKB_KEY_Control_L;
+	return pressed == false && records[0] == XKB_KEY_Control_L && records[1] == XKB_KEY_Control_L;
 }


### PR DESCRIPTION
Hi,

I found a bug can let im toggle by accident. If you press the CTRL+C keys consecutively, but release the C key first, then release the CTRL key, and then press CTRL+C again, it will trigger the im toggle. 

The reason is im toggle can trigger by  CTRL released and then CTRL pressed, so i change the im toggle is trigger only key is released.